### PR TITLE
niri final

### DIFF
--- a/hosts/aspire/default.nix
+++ b/hosts/aspire/default.nix
@@ -3,9 +3,11 @@
 {
   # Host-specific desktop selection controls.
   my.modules.desktopSpecialisations = {
+    # Desktop Environment / Window Manager build toggle
+    # default values in desktop-specialisations.nix are overwritten here
     baseDesktop = "hyprland";
     buildHyprland = true;
-    buildNiri = true;
+    buildNiri = false;
     buildKde = false;
   };
 

--- a/hosts/templates/default.nix
+++ b/hosts/templates/default.nix
@@ -5,6 +5,8 @@
   # Optional future host-local GPU config can be imported from ./gpu.nix.
 
   # Build-time desktop boot entries.
+  # Desktop Environment / Window Manager build toggle
+  # default values in desktop-specialisations.nix are overwritten here
   my.modules.desktopSpecialisations = {
     buildHyprland = true;
     buildNiri = true;

--- a/modules/desktop-specialisations.nix
+++ b/modules/desktop-specialisations.nix
@@ -12,6 +12,9 @@ in
   options.my.modules.desktopSpecialisations = {
     enable = lib.mkEnableOption "desktop specialisations";
 
+    # defaults in this module are fallbacks only
+    # host values in hosts/thehost123/default.nix decide what is actually built
+
     baseDesktop = lib.mkOption {
       type = lib.types.enum [ "hyprland" "niri" "kde" ];
       default = "hyprland";

--- a/users/default.nix
+++ b/users/default.nix
@@ -1,4 +1,4 @@
-{ users ? { }, hyprbarsPluginPackage ? null }: temporary
+{ users ? { }, hyprbarsPluginPackage ? null }: # temporary
 
 { config, ... }:
 


### PR DESCRIPTION
I realized that when publishing my repo I somehow messed up the correct config I had for niri & pushed the default .. I can't restore the old .nix file I had, which means the niri specialisation currently doesn't really work. noctalia-shell is not launching & many keybindings are simply missing

I'll try to get it to work soon; for now it's not thaaat important so I'll leave this open and occasionally change something on this branch until it's ready to merge